### PR TITLE
only unref() if the function exists

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -22,7 +22,7 @@ beam.on('connected', function () {
 beam.on('end', () => beam.end())
 
 process.stdin.pipe(beam).pipe(process.stdout)
-process.stdin.unref()
+if (typeof process.stdin.unref === 'function') process.stdin.unref()
 
 process.once('SIGINT', () => {
   if (!beam.connected) closeASAP()


### PR DESCRIPTION
when I run hyperbeam in interactive mode with a tty attached, everything appears to work fine on node 12.18.2 but when I pipe data in:

```
$ hyperbeam tux < tux-bowl.jpg
/home/substack/projects/hyperbeam/bin.js:25
process.stdin.unref()
              ^

TypeError: process.stdin.unref is not a function
    at Object.<anonymous> (/home/substack/projects/hyperbeam/bin.js:25:15)
    at Module._compile (internal/modules/cjs/loader.js:1138:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1158:10)
    at Module.load (internal/modules/cjs/loader.js:986:32)
    at Function.Module._load (internal/modules/cjs/loader.js:879:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:71:12)
    at internal/main/run_main_module.js:17:47
```

This could be a node bug in an old version, but this patch checks for the presence of `unref()` before calling it, which fixes the program for me.