### PR TITLE
Update to use a strict dictionary for passphrase generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,14 @@ npm install hyperbeam
 ``` js
 const Hyperbeam = require('hyperbeam')
 
-// 'from mafintosh' should be a somewhat unique topic used to derive a discovery key.
+// 'fraying stopping granular' is a somewhat unique passphrase used to derive a discovery key
 // to find the other side of your pipe. it's seemed with a determistic timestamp from ~+-30min for better privacy
 // once the other peer is discovered it is used to derive a noise keypair as well.
-const beam = new Hyperbeam('from mafintosh')
+const beam = new Hyperbeam('fraying stopping granular')
+
+// to generate a passphrase, leave the constructor empty and hyperbeam will generate one for you
+// const beam = new Hyperbeam()
+// beam.key // <-- your passphrase
 
 // make a little chat app
 process.stdin.pipe(beam).pipe(process.stdout)
@@ -35,29 +39,35 @@ npm install -g hyperbeam
 Then on one machine run
 
 ```sh
-echo 'hello world' | hyperbeam 'some topic'
+echo 'hello world' | hyperbeam
 ```
 
-Then on another
+This will generate a phrase, eg "fraying stopping granular". Then on another machine run
 
 ```sh
 # will print "hello world"
-hyperbeam 'some topic'
+hyperbeam fraying stopping granular
 ```
 
 That's it! Happy piping.
 
 ## API
 
-#### `const stream = new Hyperbeam(key)`
+#### `const stream = new Hyperbeam([key])`
 
 Make a new Hyperbeam duplex stream.
-
+ 
 Will auto connect to another peer making using the same key within ~30 min with an end to end encrypted tunnel.
 
 When the other peer writes it's emitted as `data` on this stream.
 
 Likewise when you write to this stream it's emitted as `data` on the other peers stream.
+
+If you do not pass a `key` into the constructor (the passphrase), one will be generated and put on `stream.key`.
+
+#### `stream.key`
+
+The passphrase used by the stream for connection.
 
 ## License
 

--- a/bin.js
+++ b/bin.js
@@ -2,12 +2,27 @@
 
 const Hyperbeam = require('./')
 
-if (process.argv.length < 3) {
-  console.error('Usage: hyperbeam <topic>')
+if (process.argv.includes('-h') || process.argv.includes('--help')) {
+  console.error('Usage: hyperbeam [passphrase]')
+  console.error('')
+  console.error('  Creates a 1-1 end-to-end encrypted network pipe.')
+  console.error('  If a passphrase is not supplied, will create a new phrase and begin listening.')
   process.exit(1)
 }
 
-const beam = new Hyperbeam(process.argv.slice(2).join(' '))
+var beam
+try {
+  beam = new Hyperbeam(process.argv.slice(2).join(' '))
+} catch (e) {
+  if (e.constructor.name === 'PassPhraseError') {
+    console.error(e.message)
+    console.error('(If you are attempting to create a new pipe, do not provide a phrase and hyperbeam will generate one for you.)')
+    process.exit(1)
+  } else {
+    throw e
+  }
+}
+console.error('[hyperbeam] Pass phrase is:', beam.key)
 
 beam.on('remote-address', function ({ host, port }) {
   if (!host) console.error('[hyperbeam] Could not detect remote address')

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const { Duplex } = require('streamx')
 const sodium = require('sodium-native')
 const hyperswarm = require('hyperswarm')
 const noise = require('noise-peer')
+const generatePassphrase = require('eff-diceware-passphrase')
 
 const MAX_DRIFT = 60e3 * 30 // thirty min
 const KEY_DRIFT = 60e3 * 2 // two min
@@ -10,7 +11,20 @@ module.exports = class Hyperbeam extends Duplex {
   constructor (key) {
     super()
 
-    this._key = key
+    var announce = false
+    if (!key) {
+      key = generatePassphrase(3).join(' ')
+      announce = true
+    } else {
+      for (let word of key.split(' ')) {
+        if (!generatePassphrase.includes(word)) {
+          throw new PassPhraseError(`Invalid pass-phrase word: "${word}". Check your spelling and try again.`)
+        }
+      }
+    }
+
+    this.key = key
+    this._announce = announce
     this._swarm = null
     this._out = null
     this._inc = null
@@ -53,9 +67,9 @@ module.exports = class Hyperbeam extends Duplex {
     const then = now - (now % KEY_DRIFT)
 
     return [
-      noise.seedKeygen(hash(encode(then, this._key))),
-      noise.seedKeygen(hash(encode(then + KEY_DRIFT, this._key))),
-      noise.seedKeygen(hash(encode(then + 2 * KEY_DRIFT, this._key)))
+      noise.seedKeygen(hash(encode(then, this.key))),
+      noise.seedKeygen(hash(encode(then + KEY_DRIFT, this.key))),
+      noise.seedKeygen(hash(encode(then + 2 * KEY_DRIFT, this.key)))
     ]
   }
 
@@ -63,8 +77,8 @@ module.exports = class Hyperbeam extends Duplex {
     const then = this._now - (this._now % MAX_DRIFT)
 
     return [
-      hash('hyperbeam', hash(encode(then, this._key))),
-      hash('hyperbeam', hash(encode(then + MAX_DRIFT, this._key)))
+      hash('hyperbeam', hash(encode(then, this.key))),
+      hash('hyperbeam', hash(encode(then + MAX_DRIFT, this.key)))
     ]
   }
 
@@ -126,8 +140,8 @@ module.exports = class Hyperbeam extends Duplex {
       })
     })
 
-    this._swarm.join(a, { lookup: true, announce: true })
-    this._swarm.join(b, { lookup: true, announce: true })
+    this._swarm.join(a, { lookup: true, announce: this._announce })
+    this._swarm.join(b, { lookup: true, announce: this._announce })
   }
 
   _read (cb) {
@@ -186,4 +200,17 @@ function hash (data, seed) {
   if (seed) sodium.crypto_generichash(out, Buffer.from(data), seed)
   else sodium.crypto_generichash(out, Buffer.from(data))
   return out
+}
+
+class PassPhraseError extends Error {
+  constructor(msg) {
+    super(msg)
+    this.name = this.constructor.name
+    this.message = msg
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, this.constructor)
+    } else {
+      this.stack = (new Error(msg)).stack
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "hyperbeam": "./bin.js"
   },
   "dependencies": {
+    "eff-diceware-passphrase": "^3.0.0",
     "hyperswarm": "^2.15.2",
     "noise-peer": "^2.1.1",
     "sodium-native": "^3.2.0",


### PR DESCRIPTION
Changes:

- Passphrase are now generated from https://github.com/emilbayes/eff-diceware-passphrase if none is given
- Passphrase is validated against the ^ wordlist and so must be generated from that dictionary
- Constructor can now accept no args and will generate a passphrase
- Now only announces on the DHT if the passphrase was generated (assumes "server" role)
- Changed `._key` to `.key` as it's now needed as a public attribute for fetching the generated key
- Modified `bin.js` to match new behaviors