### PR TITLE
Extract swarm into swarm.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,30 +1,28 @@
 const { Duplex } = require('streamx')
-const sodium = require('sodium-native')
-const hyperswarm = require('hyperswarm')
-const noise = require('noise-peer')
-
-const MAX_DRIFT = 60e3 * 30 // thirty min
-const KEY_DRIFT = 60e3 * 2 // two min
+const BeamSwarm = require('./swarm')
 
 module.exports = class Hyperbeam extends Duplex {
-  constructor (key) {
+  constructor(key) {
     super()
 
     this._key = key
-    this._swarm = null
     this._out = null
     this._inc = null
     this._now = Date.now()
     this._ondrain = null
     this._onopen = null
     this._onread = null
+
+    this._swarm = new BeamSwarm(this._key)
+    this._swarm.on('remote-address', addr => this.emit('remote-address', addr))
+    this._swarm.once('connected', () => this.emit('connected'))
   }
 
-  get connected () {
+  get connected() {
     return !!this._out
   }
 
-  _ondrainDone (err) {
+  _ondrainDone(err) {
     if (this._ondrain) {
       const cb = this._ondrain
       this._ondrain = null
@@ -32,7 +30,7 @@ module.exports = class Hyperbeam extends Duplex {
     }
   }
 
-  _onreadDone (err) {
+  _onreadDone(err) {
     if (this._onread) {
       const cb = this._onread
       this._onread = null
@@ -40,7 +38,7 @@ module.exports = class Hyperbeam extends Duplex {
     }
   }
 
-  _onopenDone (err) {
+  _onopenDone(err) {
     if (this._onopen) {
       const cb = this._onopen
       this._onopen = null
@@ -48,105 +46,54 @@ module.exports = class Hyperbeam extends Duplex {
     }
   }
 
-  _keys () {
-    const now = Date.now()
-    const then = now - (now % KEY_DRIFT)
-
-    return [
-      noise.seedKeygen(hash(encode(then, this._key))),
-      noise.seedKeygen(hash(encode(then + KEY_DRIFT, this._key))),
-      noise.seedKeygen(hash(encode(then + 2 * KEY_DRIFT, this._key)))
-    ]
-  }
-
-  _dkeys () {
-    const then = this._now - (this._now % MAX_DRIFT)
-
-    return [
-      hash('hyperbeam', hash(encode(then, this._key))),
-      hash('hyperbeam', hash(encode(then + MAX_DRIFT, this._key)))
-    ]
-  }
-
-  _open (cb) {
-    const [a, b] = this._dkeys()
-
+  _open(cb) {
     this._onopen = cb
-    this._swarm = hyperswarm({ preferredPort: 49737, ephemeral: true, queue: { multiplex: true } })
-
-    this._swarm.on('listening', () => {
-      this._swarm.network.discovery.dht.on('initial-nodes', () => {
-        this.emit('remote-address', this._swarm.network.discovery.dht.remoteAddress() || { host: null, port: 0 })
-      })
-    })
-    this._swarm.on('connection', (connection, info) => {
-      if (info.type === 'tcp') connection.allowHalfOpen = true
-      connection.on('error', () => {})
-
-      const staticKeyPairs = this._keys()
-
-      const s = noise(connection, info.client, {
-        pattern: 'XX',
-        staticKeyPair: staticKeyPairs[1],
-        onstatickey (remotePublicKey, cb) {
-          for (const { publicKey } of staticKeyPairs) {
-            if (publicKey.equals(remotePublicKey)) return cb(null)
-          }
-
-          cb(new Error('Remote public key did not match'))
+    this._swarm.open()
+    this._swarm.on('connection', (s, info) => {
+      s.on('data', (data) => {
+        if (!this._inc) {
+          this._inc = s
+          this._inc.on('error', (err) => this.destroy(err))
+          this._inc.on('end', () => this._push(null))
         }
+
+        if (s !== this._inc) return
+        if (this._push(data) === false) s.pause()
       })
 
-      s.on('handshake', () => {
-        s.on('data', (data) => {
-          if (!this._inc) {
-            this._inc = s
-            this._inc.on('error', (err) => this.destroy(err))
-            this._inc.on('end', () => this._push(null))
-          }
-
-          if (s !== this._inc) return
-          if (this._push(data) === false) s.pause()
-        })
-
-        s.on('end', () => {
-          if (this._inc) return
-          this._push(null)
-        })
-
-        if (!this._out) {
-          this._out = s
-          this._out.on('error', (err) => this.destroy(err))
-          this._out.on('drain', () => this._ondrain(null))
-          this._swarm.leave(a)
-          this._swarm.leave(b)
-          this.emit('connected')
-          this._onopenDone(null)
-        }
+      s.on('end', () => {
+        if (this._inc) return
+        this._push(null)
       })
+
+      if (!this._out) {
+        this._out = s
+        this._out.on('error', (err) => this.destroy(err))
+        this._out.on('drain', () => this._ondrain(null))
+        this._swarm.leave()
+        this.emit('connected')
+        this._onopenDone(null)
+      }
     })
-
-    this._swarm.join(a, { lookup: true, announce: true })
-    this._swarm.join(b, { lookup: true, announce: true })
   }
 
-  _read (cb) {
+  _read(cb) {
     this._onread = cb
     if (this._inc) this._inc.resume()
   }
 
-  _push (data) {
+  _push(data) {
     const res = this.push(data)
     process.nextTick(() => this._onreadDone(null))
     return res
   }
 
-  _write (data, cb) {
+  _write(data, cb) {
     if (this._out.write(data) !== false) return cb(null)
     this._ondrain = cb
   }
 
-  _final (cb) {
+  _final(cb) {
     const done = () => {
       this._out.removeListener('finish', done)
       this._out.removeListener('error', done)
@@ -158,7 +105,7 @@ module.exports = class Hyperbeam extends Duplex {
     this._out.on('error', done)
   }
 
-  _predestroy () {
+  _predestroy() {
     if (this._inc) this._inc.destroy()
     if (this._out) this._out.destroy()
     const err = new Error('Destroyed')
@@ -167,23 +114,8 @@ module.exports = class Hyperbeam extends Duplex {
     this._ondrainDone(err)
   }
 
-  _destroy (cb) {
-    if (!this._swarm) return cb(null)
-    this._swarm.on('close', () => cb(null))
-    this._swarm.destroy()
+  _destroy(cb) {
+    return this._swarm.destroy(cb)
   }
 }
 
-function encode (num, key) {
-  const buf = Buffer.alloc(8 + Buffer.byteLength(key))
-  buf.writeDoubleBE(num)
-  buf.write(key, 8)
-  return buf
-}
-
-function hash (data, seed) {
-  const out = Buffer.alloc(32)
-  if (seed) sodium.crypto_generichash(out, Buffer.from(data), seed)
-  else sodium.crypto_generichash(out, Buffer.from(data))
-  return out
-}

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports = class Hyperbeam extends Duplex {
   _open(cb) {
     this._onopen = cb
     this._swarm.open()
-    this._swarm.on('connection', (s, info) => {
+    this._swarm.on('connection', s => {
       s.on('data', (data) => {
         if (!this._inc) {
           this._inc = s

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const { Duplex } = require('streamx')
 const BeamSwarm = require('./swarm')
 
 module.exports = class Hyperbeam extends Duplex {
-  constructor(key) {
+  constructor (key) {
     super()
 
     this._key = key
@@ -18,11 +18,11 @@ module.exports = class Hyperbeam extends Duplex {
     this._swarm.once('connected', () => this.emit('connected'))
   }
 
-  get connected() {
+  get connected () {
     return !!this._out
   }
 
-  _ondrainDone(err) {
+  _ondrainDone (err) {
     if (this._ondrain) {
       const cb = this._ondrain
       this._ondrain = null
@@ -30,7 +30,7 @@ module.exports = class Hyperbeam extends Duplex {
     }
   }
 
-  _onreadDone(err) {
+  _onreadDone (err) {
     if (this._onread) {
       const cb = this._onread
       this._onread = null
@@ -38,7 +38,7 @@ module.exports = class Hyperbeam extends Duplex {
     }
   }
 
-  _onopenDone(err) {
+  _onopenDone (err) {
     if (this._onopen) {
       const cb = this._onopen
       this._onopen = null
@@ -46,7 +46,7 @@ module.exports = class Hyperbeam extends Duplex {
     }
   }
 
-  _open(cb) {
+  _open (cb) {
     this._onopen = cb
     this._swarm.open()
     this._swarm.on('connection', s => {
@@ -77,23 +77,23 @@ module.exports = class Hyperbeam extends Duplex {
     })
   }
 
-  _read(cb) {
+  _read (cb) {
     this._onread = cb
     if (this._inc) this._inc.resume()
   }
 
-  _push(data) {
+  _push (data) {
     const res = this.push(data)
     process.nextTick(() => this._onreadDone(null))
     return res
   }
 
-  _write(data, cb) {
+  _write (data, cb) {
     if (this._out.write(data) !== false) return cb(null)
     this._ondrain = cb
   }
 
-  _final(cb) {
+  _final (cb) {
     const done = () => {
       this._out.removeListener('finish', done)
       this._out.removeListener('error', done)
@@ -105,7 +105,7 @@ module.exports = class Hyperbeam extends Duplex {
     this._out.on('error', done)
   }
 
-  _predestroy() {
+  _predestroy () {
     if (this._inc) this._inc.destroy()
     if (this._out) this._out.destroy()
     const err = new Error('Destroyed')
@@ -114,8 +114,7 @@ module.exports = class Hyperbeam extends Duplex {
     this._ondrainDone(err)
   }
 
-  _destroy(cb) {
+  _destroy (cb) {
     return this._swarm.destroy(cb)
   }
 }
-

--- a/swarm.js
+++ b/swarm.js
@@ -39,7 +39,7 @@ module.exports = class BeamSwarm extends EventEmitter {
 
   open () {
     this._dkeys()
-    this._swarm = hyperswarm({ preferredPort: 49737, ephemeral: true, queue: { multiplex: true } })
+    this._swarm = hyperswarm({ announceLocalNetwork: true, preferredPort: 49737, ephemeral: true, queue: { multiplex: true } })
 
     this._swarm.on('listening', () => {
       this._swarm.network.discovery.dht.on('initial-nodes', () => {

--- a/swarm.js
+++ b/swarm.js
@@ -1,0 +1,97 @@
+const { EventEmitter } = require('events')
+const sodium = require('sodium-native')
+const hyperswarm = require('hyperswarm')
+const noise = require('noise-peer')
+
+const MAX_DRIFT = 60e3 * 30 // thirty min
+const KEY_DRIFT = 60e3 * 2 // two min
+
+module.exports = class BeamSwarm extends EventEmitter {
+  constructor (key) {
+    super()
+    this._key = key
+    this._now = Date.now()
+    this._swarm = null
+  }
+
+  _keys () {
+    const now = Date.now()
+    const then = now - (now % KEY_DRIFT)
+
+    return [
+      noise.seedKeygen(hash(encode(then, this._key))),
+      noise.seedKeygen(hash(encode(then + KEY_DRIFT, this._key))),
+      noise.seedKeygen(hash(encode(then + 2 * KEY_DRIFT, this._key)))
+    ]
+  }
+
+  _dkeys () {
+    const then = this._now - (this._now % MAX_DRIFT)
+
+    return [
+      hash('hyperbeam', hash(encode(then, this._key))),
+      hash('hyperbeam', hash(encode(then + MAX_DRIFT, this._key)))
+    ]
+  }
+
+  open () {
+    const [a, b] = this._dkeys()
+    this._swarm = hyperswarm({ preferredPort: 49737, ephemeral: true, queue: { multiplex: true } })
+
+    this._swarm.on('listening', () => {
+      this._swarm.network.discovery.dht.on('initial-nodes', () => {
+        this.emit('remote-address', this._swarm.network.discovery.dht.remoteAddress() || { host: null, port: 0 })
+      })
+    })
+    this._swarm.on('connection', (connection, info) => {
+      if (info.type === 'tcp') connection.allowHalfOpen = true
+      connection.on('error', () => {})
+
+      const staticKeyPairs = this._keys()
+
+      const s = noise(connection, info.client, {
+        pattern: 'XX',
+        staticKeyPair: staticKeyPairs[1],
+        onstatickey (remotePublicKey, cb) {
+          for (const { publicKey } of staticKeyPairs) {
+            if (publicKey.equals(remotePublicKey)) return cb(null)
+          }
+
+          cb(new Error('Remote public key did not match'))
+        }
+      })
+
+      s.on('handshake', () => {
+        this.emit('connection', s, info)
+      })
+    })
+
+    this._swarm.join(a, { lookup: true, announce: true })
+    this._swarm.join(b, { lookup: true, announce: true })
+  }
+
+  leave () {
+    this._swarm.leave(a)
+    this._swarm.leave(b)
+  }
+
+  destroy (cb) {
+    if (!this._swarm) return cb(null)
+    this._swarm.on('close', () => cb(null))
+    this._swarm.destroy()
+  }
+}
+
+function encode (num, key) {
+  const buf = Buffer.alloc(8 + Buffer.byteLength(key))
+  buf.writeDoubleBE(num)
+  buf.write(key, 8)
+  return buf
+}
+
+function hash (data, seed) {
+  const out = Buffer.alloc(32)
+  if (seed) sodium.crypto_generichash(out, Buffer.from(data), seed)
+  else sodium.crypto_generichash(out, Buffer.from(data))
+  return out
+}

--- a/swarm.js
+++ b/swarm.js
@@ -65,7 +65,7 @@ module.exports = class BeamSwarm extends EventEmitter {
       })
 
       s.on('handshake', () => {
-        this.emit('connection', s, info)
+        this.emit('connection', s, connection, info)
       })
     })
 


### PR DESCRIPTION
Hyperbeam's logic for creating one-off swarms with E2E encrypted connections is generally useful. This PR extracts the swarming logic into `swarm.js`, so that it can be imported elsewhere with `require('hyperbeam/swarm')`